### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/yinkaolotin/olotin1/compare/v0.1.5...v0.1.6) - 2025-04-23
+
+### Fixed
+
+- change to h
+
 ## [0.1.5](https://github.com/yinkaolotin/olotin1/compare/v0.1.4...v0.1.5) - 2025-04-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "olotin1"
-version = "0.1.5"
+version = "0.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "olotin1"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 repository = "https://github.com/yinkaolotin/olotin1"
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
 fn main() {
     println!("Hello, world!");
-    _ = "g";
+    _ = "h";
 }


### PR DESCRIPTION



## 🤖 New release

* `olotin1`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/yinkaolotin/olotin1/compare/v0.1.5...v0.1.6) - 2025-04-23

### Fixed

- change to h
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).