### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/yinkaolotin/olotin1/compare/v0.1.6...v0.1.7) - 2025-04-23
+
+### Fixed
+
+- change to j
+
 ## [0.1.6](https://github.com/yinkaolotin/olotin1/compare/v0.1.5...v0.1.6) - 2025-04-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "olotin1"
-version = "0.1.6"
+version = "0.1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "olotin1"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 repository = "https://github.com/yinkaolotin/olotin1"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `olotin1`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/yinkaolotin/olotin1/compare/v0.1.6...v0.1.7) - 2025-04-23

### Fixed

- change to j
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).